### PR TITLE
point cloud instanced rendering

### DIFF
--- a/threecrate-gpu/src/lib.rs
+++ b/threecrate-gpu/src/lib.rs
@@ -51,8 +51,9 @@ pub use nearest_neighbor::{gpu_find_k_nearest, gpu_find_k_nearest_batch, gpu_fin
 pub use icp::gpu_icp;
 pub use tsdf::{gpu_tsdf_integrate, gpu_tsdf_extract_surface, create_tsdf_volume, TsdfVolume, TsdfVoxel, CameraIntrinsics, TsdfVolumeGpu};
 pub use renderer::{
-    PointCloudRenderer, PointVertex, RenderConfig, RenderParams, CameraUniform,
-    point_cloud_to_vertices, point_cloud_to_vertices_colored, colored_point_cloud_to_vertices
+    PointCloudRenderer, PointVertex, PointInstanceData, RenderConfig, RenderParams, CameraUniform,
+    point_cloud_to_vertices, point_cloud_to_vertices_colored, colored_point_cloud_to_vertices,
+    point_cloud_to_instance_data, colored_point_cloud_to_instance_data,
 };
 pub use mesh::{
     MeshRenderer, MeshVertex, MeshCameraUniform, PbrMaterial, FlatMaterial, 

--- a/threecrate-gpu/src/shaders/point_cloud_instanced.wgsl
+++ b/threecrate-gpu/src/shaders/point_cloud_instanced.wgsl
@@ -1,0 +1,70 @@
+// Instanced point cloud rendering: one quad per point, no CPU quad generation.
+// Unit quad vertices (slot 0-3) + instance buffer (position, color per point).
+
+struct CameraUniform {
+    view_proj: mat4x4<f32>,
+    view_pos: vec3<f32>,
+    _padding: f32,
+}
+
+struct RenderParams {
+    point_size: f32,
+    alpha_threshold: f32,
+    enable_splatting: f32,
+    enable_lighting: f32,
+    ambient_strength: f32,
+    diffuse_strength: f32,
+    specular_strength: f32,
+    shininess: f32,
+}
+
+// Unit quad vertex: offset from center (-0.5 to 0.5 in XY plane)
+struct QuadVertexInput {
+    @location(0) offset: vec3<f32>,
+}
+
+// Instance data: one per point
+struct InstanceInput {
+    @location(1) position: vec3<f32>,
+    @location(2) color: vec3<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) color: vec3<f32>,
+    @location(1) world_pos: vec3<f32>,
+}
+
+@group(0) @binding(0)
+var<uniform> camera: CameraUniform;
+
+@group(0) @binding(1)
+var<uniform> render_params: RenderParams;
+
+@vertex
+fn vs_main(
+    quad: QuadVertexInput,
+    instance: InstanceInput,
+) -> VertexOutput {
+    var out: VertexOutput;
+
+    // Scale quad by point_size and place at instance position
+    let point_size = render_params.point_size;
+    let world_pos = instance.position + quad.offset * point_size;
+
+    out.clip_position = camera.view_proj * vec4<f32>(world_pos, 1.0);
+    out.color = instance.color;
+    out.world_pos = world_pos;
+
+    return out;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    // Simple shading: slight falloff by distance
+    let distance_to_camera = length(input.world_pos - camera.view_pos);
+    let distance_factor = 1.0 / (1.0 + distance_to_camera * 0.01);
+    let final_color = input.color * (0.8 + 0.2 * distance_factor);
+
+    return vec4<f32>(final_color, 1.0);
+}


### PR DESCRIPTION
## Solution: [Instanced Rendering](https://github.com/rajgandhi1/threecrate/issues/79)

### Approach

Instead of generating 6 vertices per point, **instanced rendering** is used:

1. **Unit quad** — a single quad (4 vertices, 6 indices) in the vertex buffer, shared by all points
2. **Instance buffer** — per-point data: only `position` and `color` (24 bytes)
3. **Vertex shader** — places the quad at each point: `world_pos = instance_position + quad_offset * point_size`

### Benefits

| Metric | Before | After |
|--------|--------|-------|
| Data per point | ~336 bytes (6 × PointVertex) | 24 bytes (PointInstanceData) |
| Buffer for 100k points | ~33 MB | ~2.4 MB |
| CPU for conversion | O(6n) operations every frame | O(n) single pass |
| Vertex buffer | Created every frame | Unit quad — once |
| Instance buffer | — | Updated when cloud changes |

### Implemented Changes

#### 1. threecrate-gpu

- **`PointInstanceData`** — struct `{ position: [f32;3], color: [f32;3] }`
- **`point_cloud_to_instance_data()`** — converts `PointCloud<Point3f>` → `Vec<PointInstanceData>`
- **`colored_point_cloud_to_instance_data()`** — converts `PointCloud<ColoredPoint3f>` → `Vec<PointInstanceData>`
- **`point_cloud_instanced.wgsl`** — shader for instanced rendering
- **`PointCloudRenderer::render_instanced()`** — rendering method using instancing

#### 2. threecrate-visualization

- `InteractiveViewer` switched to `render_instanced()`
- CPU quad generation removed
- Point size configured via `RenderParams.point_size` (default 0.04)

---

## API

### New Types and Functions

```rust
// threecrate-gpu
pub struct PointInstanceData {
    pub position: [f32; 3],
    pub color: [f32; 3],
}

pub fn point_cloud_to_instance_data(
    cloud: &PointCloud<Point3f>,
    color: [f32; 3],
) -> Vec<PointInstanceData>;

pub fn colored_point_cloud_to_instance_data(
    cloud: &PointCloud<ColoredPoint3f>,
) -> Vec<PointInstanceData>;

impl PointCloudRenderer {
    pub fn render_instanced(&self, instances: &[PointInstanceData]) -> Result<()>;
}
```

### Backward Compatibility

The `render(&[PointVertex])` method is retained for code using the legacy format. Gradual migration to `render_instanced()` is recommended.
