### PR TITLE
rng: fix 2 deprecated methods

### DIFF
--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -153,7 +153,7 @@ fn noisy_icp_example() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Create target points with known transformation + noise
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     for point in &source.points {
         let transformed = transform * point;
         // Add Gaussian noise

--- a/examples/comprehensive_gpu_example.rs
+++ b/examples/comprehensive_gpu_example.rs
@@ -393,7 +393,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn generate_sample_data() -> (PointCloud<Point3f>, PointCloud<Point3f>, Vec<f32>) {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     // Generate first point cloud (sphere)
     let mut source_points = Vec::new();

--- a/examples/euclidean_cluster_example.rs
+++ b/examples/euclidean_cluster_example.rs
@@ -4,7 +4,7 @@
 //! with multiple spatially-separated object blobs, as implemented for issue #95.
 
 use rand::prelude::*;
-use rand::thread_rng;
+use rand::rng;
 use threecrate_algorithms::{
     extract_euclidean_clusters, extract_euclidean_clusters_parallel, EuclideanClusterConfig,
 };
@@ -67,7 +67,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// Three sphere-shaped blobs at well-separated positions
 fn create_three_blobs() -> PointCloud<Point3f> {
     let mut cloud = PointCloud::new();
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     let blobs = [
         (Point3f::new(0.0, 0.0, 0.0), 0.4_f32, 500_usize),
@@ -94,7 +94,7 @@ fn create_three_blobs() -> PointCloud<Point3f> {
 /// A denser scene with four blobs
 fn create_dense_scene() -> PointCloud<Point3f> {
     let mut cloud = PointCloud::new();
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     let blobs = [
         (Point3f::new(0.0, 0.0, 0.0), 0.5_f32, 1000_usize),
@@ -122,7 +122,7 @@ fn create_dense_scene() -> PointCloud<Point3f> {
 /// Two large blobs plus several tiny noise blobs that should be filtered out
 fn create_cloud_with_noise_blobs() -> PointCloud<Point3f> {
     let mut cloud = PointCloud::new();
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     // Large blobs
     for (center, radius, count) in [

--- a/examples/gpu_example.rs
+++ b/examples/gpu_example.rs
@@ -111,7 +111,7 @@ fn create_sample_point_cloud(num_points: usize, offset: f32) -> PointCloud<Point
 /// Add random outliers to a point cloud for testing filtering
 fn add_outliers(cloud: &mut PointCloud<Point3f>, num_outliers: usize) {
     use rand::Rng;
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     for _ in 0..num_outliers {
         // Add points far from the main cluster

--- a/examples/k_nearest_neighbors_example.rs
+++ b/examples/k_nearest_neighbors_example.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Created point cloud with {} points", cloud.len());
 
     // Add some random points for more interesting results
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     for _ in 0..20 {
         cloud.push(Point3f::new(
             rng.random_range(-2.0..7.0),

--- a/examples/ransac_plane_example.rs
+++ b/examples/ransac_plane_example.rs
@@ -4,9 +4,9 @@
 //! on noisy planar point clouds, as requested in GitHub issue #4.
 
 use rand::prelude::*;
+use rand::rng;
 use threecrate_algorithms::{plane_segmentation_ransac, segment_plane_ransac};
 use threecrate_core::{Point3f, PointCloud};
-use rand::rng;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== RANSAC Plane Segmentation Example ===\n");

--- a/examples/ransac_plane_example.rs
+++ b/examples/ransac_plane_example.rs
@@ -4,9 +4,9 @@
 //! on noisy planar point clouds, as requested in GitHub issue #4.
 
 use rand::prelude::*;
-use rand::thread_rng;
 use threecrate_algorithms::{plane_segmentation_ransac, segment_plane_ransac};
 use threecrate_core::{Point3f, PointCloud};
+use rand::rng;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== RANSAC Plane Segmentation Example ===\n");
@@ -99,7 +99,7 @@ fn create_simple_planar_cloud() -> PointCloud<Point3f> {
 /// Create a noisy planar point cloud
 fn create_noisy_planar_cloud() -> PointCloud<Point3f> {
     let mut cloud = PointCloud::new();
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     // Create a 20x20 grid on the XY plane with noise
     for i in 0..20 {
@@ -125,7 +125,7 @@ fn create_noisy_planar_cloud() -> PointCloud<Point3f> {
 /// Create a tilted plane with outliers
 fn create_tilted_plane_with_outliers() -> PointCloud<Point3f> {
     let mut cloud = PointCloud::new();
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     // Create a tilted plane: x + y + z = 0
     for i in 0..15 {
@@ -157,7 +157,7 @@ fn create_tilted_plane_with_outliers() -> PointCloud<Point3f> {
 /// Create multiple planes (for demonstrating single plane detection)
 fn create_multiple_planes() -> PointCloud<Point3f> {
     let mut cloud = PointCloud::new();
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     // First plane: z = 0 (largest)
     for i in 0..25 {

--- a/threecrate-algorithms/src/ground_segmentation.rs
+++ b/threecrate-algorithms/src/ground_segmentation.rs
@@ -430,9 +430,9 @@ mod tests {
         // Flat ground at z = -sensor_height over a 60×60 area, with mild noise.
         let z_ground = -sensor_height;
         for _ in 0..8000 {
-            let x: f32 = rng.gen_range(-30.0..30.0);
-            let y: f32 = rng.gen_range(-30.0..30.0);
-            let z = z_ground + rng.gen_range(-0.02..0.02);
+            let x: f32 = rng.random_range(-30.0..30.0);
+            let y: f32 = rng.random_range(-30.0..30.0);
+            let z = z_ground + rng.random_range(-0.02..0.02);
             // Skip points right under the sensor (too close to origin).
             if x * x + y * y < 0.25 {
                 continue;
@@ -443,16 +443,16 @@ mod tests {
         if with_obstacles {
             // Tall vertical "wall" / obstacle cluster.
             for _ in 0..1500 {
-                let x = 8.0 + rng.gen_range(-0.4..0.4);
-                let y = rng.gen_range(-3.0..3.0);
-                let z = z_ground + rng.gen_range(0.5..3.0);
+                let x = 8.0 + rng.random_range(-0.4..0.4);
+                let y = rng.random_range(-3.0..3.0);
+                let z = z_ground + rng.random_range(0.5..3.0);
                 cloud.push(Point3f::new(x, y, z));
             }
             // A pole.
             for _ in 0..400 {
-                let x = -5.0 + rng.gen_range(-0.1..0.1);
-                let y = -5.0 + rng.gen_range(-0.1..0.1);
-                let z = z_ground + rng.gen_range(0.0..4.0);
+                let x = -5.0 + rng.random_range(-0.1..0.1);
+                let y = -5.0 + rng.random_range(-0.1..0.1);
+                let z = z_ground + rng.random_range(0.0..4.0);
                 cloud.push(Point3f::new(x, y, z));
             }
         }

--- a/threecrate-algorithms/src/nearest_neighbor.rs
+++ b/threecrate-algorithms/src/nearest_neighbor.rs
@@ -549,15 +549,15 @@ mod tests {
 
     #[test]
     fn test_random_points() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut points = Vec::new();
 
         // Generate 100 random points
         for _ in 0..100 {
             points.push(Point3f::new(
-                rng.gen_range(-10.0..10.0),
-                rng.gen_range(-10.0..10.0),
-                rng.gen_range(-10.0..10.0),
+                rng.random_range(-10.0..10.0),
+                rng.random_range(-10.0..10.0),
+                rng.random_range(-10.0..10.0),
             ));
         }
 
@@ -567,13 +567,13 @@ mod tests {
         // Test multiple random queries
         for _ in 0..10 {
             let query = Point3f::new(
-                rng.gen_range(-5.0..5.0),
-                rng.gen_range(-5.0..5.0),
-                rng.gen_range(-5.0..5.0),
+                rng.random_range(-5.0..5.0),
+                rng.random_range(-5.0..5.0),
+                rng.random_range(-5.0..5.0),
             );
 
-            let k = rng.gen_range(1..=10);
-            let radius = rng.gen_range(1.0..5.0);
+            let k = rng.random_range(1..=10);
+            let radius = rng.random_range(1.0..5.0);
 
             let mut kdtree_knn = kdtree.find_k_nearest(&query, k);
             let mut brute_knn = brute_force.find_k_nearest(&query, k);
@@ -627,15 +627,15 @@ mod tests {
 
     #[test]
     fn test_performance_comparison() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut points = Vec::new();
 
         // Generate 1000 random points for performance test
         for _ in 0..1000 {
             points.push(Point3f::new(
-                rng.gen_range(-10.0..10.0),
-                rng.gen_range(-10.0..10.0),
-                rng.gen_range(-10.0..10.0),
+                rng.random_range(-10.0..10.0),
+                rng.random_range(-10.0..10.0),
+                rng.random_range(-10.0..10.0),
             ));
         }
 

--- a/threecrate-algorithms/src/segmentation.rs
+++ b/threecrate-algorithms/src/segmentation.rs
@@ -3,8 +3,8 @@
 use crate::KdTree;
 use nalgebra::Vector4;
 use rand::prelude::*;
-use rayon::prelude::*;
 use rand::rng;
+use rayon::prelude::*;
 use std::collections::{HashSet, VecDeque};
 use threecrate_core::NearestNeighborSearch;
 use threecrate_core::{Error, Point3f, PointCloud, Result, Vector3f};

--- a/threecrate-algorithms/src/segmentation.rs
+++ b/threecrate-algorithms/src/segmentation.rs
@@ -3,8 +3,8 @@
 use crate::KdTree;
 use nalgebra::Vector4;
 use rand::prelude::*;
-use rand::thread_rng;
 use rayon::prelude::*;
+use rand::rng;
 use std::collections::{HashSet, VecDeque};
 use threecrate_core::NearestNeighborSearch;
 use threecrate_core::{Error, Point3f, PointCloud, Result, Vector3f};
@@ -136,7 +136,7 @@ pub fn segment_plane(
     }
 
     let points = &cloud.points;
-    let mut rng = thread_rng();
+    let mut rng = rng();
     let mut best_model: Option<PlaneModel> = None;
     let mut best_inliers = Vec::new();
     let mut best_score = 0;
@@ -145,7 +145,7 @@ pub fn segment_plane(
         // Randomly sample 3 points
         let mut indices = HashSet::new();
         while indices.len() < 3 {
-            indices.insert(rng.gen_range(0..points.len()));
+            indices.insert(rng.random_range(0..points.len()));
         }
         let indices: Vec<usize> = indices.into_iter().collect();
 
@@ -218,12 +218,12 @@ pub fn segment_plane_parallel(
     let results: Vec<_> = (0..max_iters)
         .into_par_iter()
         .filter_map(|_| {
-            let mut rng = thread_rng();
+            let mut rng = rng();
 
             // Randomly sample 3 points
             let mut indices = HashSet::new();
             while indices.len() < 3 {
-                indices.insert(rng.gen_range(0..points.len()));
+                indices.insert(rng.random_range(0..points.len()));
             }
             let indices: Vec<usize> = indices.into_iter().collect();
 
@@ -711,23 +711,23 @@ mod tests {
     fn test_segment_plane_ransac_noisy() {
         // Create a point cloud with noisy planar points
         let mut cloud = PointCloud::new();
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         // Add points on XY plane (z=0) with noise
         for i in 0..20 {
             for j in 0..20 {
                 let x = i as f32;
                 let y = j as f32;
-                let z = rng.gen_range(-0.05..0.05); // Add noise to z coordinate
+                let z = rng.random_range(-0.05..0.05); // Add noise to z coordinate
                 cloud.push(Point3f::new(x, y, z));
             }
         }
 
         // Add some outliers
         for _ in 0..20 {
-            let x = rng.gen_range(0.0..20.0);
-            let y = rng.gen_range(0.0..20.0);
-            let z = rng.gen_range(1.0..5.0); // Outliers above the plane
+            let x = rng.random_range(0.0..20.0);
+            let y = rng.random_range(0.0..20.0);
+            let z = rng.random_range(1.0..5.0); // Outliers above the plane
             cloud.push(Point3f::new(x, y, z));
         }
 
@@ -764,7 +764,7 @@ mod tests {
     fn test_segment_plane_ransac_tilted_plane() {
         // Create a tilted plane (not aligned with coordinate axes)
         let mut cloud = PointCloud::new();
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         // Create a tilted plane: x + y + z = 0
         for i in 0..15 {
@@ -774,9 +774,9 @@ mod tests {
                 let z = -(x + y); // Points on the plane x + y + z = 0
 
                 // Add some noise
-                let noise_x = rng.gen_range(-0.02..0.02);
-                let noise_y = rng.gen_range(-0.02..0.02);
-                let noise_z = rng.gen_range(-0.02..0.02);
+                let noise_x = rng.random_range(-0.02..0.02);
+                let noise_y = rng.random_range(-0.02..0.02);
+                let noise_z = rng.random_range(-0.02..0.02);
 
                 cloud.push(Point3f::new(x + noise_x, y + noise_y, z + noise_z));
             }
@@ -784,9 +784,9 @@ mod tests {
 
         // Add outliers
         for _ in 0..30 {
-            let x = rng.gen_range(0.0..15.0);
-            let y = rng.gen_range(0.0..15.0);
-            let z = rng.gen_range(5.0..10.0); // Outliers above the plane
+            let x = rng.random_range(0.0..15.0);
+            let y = rng.random_range(0.0..15.0);
+            let z = rng.random_range(5.0..10.0); // Outliers above the plane
             cloud.push(Point3f::new(x, y, z));
         }
 
@@ -873,12 +873,12 @@ mod tests {
     // ---- Euclidean cluster extraction tests ----
 
     fn make_sphere_cloud(center: Point3f, radius: f32, count: usize) -> Vec<Point3f> {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut pts = Vec::with_capacity(count);
         while pts.len() < count {
-            let x: f32 = rng.gen_range(-radius..radius);
-            let y: f32 = rng.gen_range(-radius..radius);
-            let z: f32 = rng.gen_range(-radius..radius);
+            let x: f32 = rng.random_range(-radius..radius);
+            let y: f32 = rng.random_range(-radius..radius);
+            let z: f32 = rng.random_range(-radius..radius);
             if x * x + y * y + z * z <= radius * radius {
                 pts.push(Point3f::new(center.x + x, center.y + y, center.z + z));
             }


### PR DESCRIPTION
## What does this PR do?

There are two deprecated function call the need fixing

A)
- let mut rng = thread_rng();
+ let mut rng = rng();

B)
- let x = -5.0 + rng.gen_range(-0.1..0.1);
+ let x = -5.0 + rng.random_range(-0.1..0.1);


